### PR TITLE
Give pymssql dependency an upper bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymssql
+pymssql<3.0


### PR DESCRIPTION
The builds for this pack started to [fail](https://circleci.com/gh/StackStorm-Exchange/stackstorm-mssql/145) due to [python-mssql being discontinued](https://github.com/pymssql/pymssql/issues/668).

The workaround is to simply limit the `mssql` dependency to `<3.0` to avoid the exception bomb in newer versions of `setup.py`.